### PR TITLE
Add getListenersPriority(eventName, listener) to EventDispatcherAbstract

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/event-dispatcher": "~2.0",
+        "symfony/event-dispatcher": "~2.8|~3.0",
         "illuminate/events": "~5.0",
         "doctrine/cache": ">=1.3.0",
         "monolog/monolog": ">=1.7.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php-tmdb/api": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.5",
         "symfony/event-dispatcher": "~2.8|~3.0",
         "illuminate/events": "~5.0",
         "doctrine/cache": ">=1.3.0",

--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -14,20 +14,20 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyDispatc
  * This adapter provides a Laravel integration for applications
  * using the Symfony EventDispatcherInterface
  * It passes any request on to a Symfony Dispatcher and only
- * uses the Laravel Dispatcher only when dispatching events
+ * uses the Laravel Dispatcher when dispatching events
  */
 abstract class EventDispatcherAdapter implements SymfonyDispatcher
 {
 
     /**
      * The Laravel Events Dispatcher
-     * @var Illuminate\Contracts\Events\Dispatcher or Illuminate\Events\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher or \Illuminate\Events\Dispatcher
      */
     protected $laravelDispatcher;
 
     /**
      * The Symfony Event Dispatcher
-     * @var  Symfony\Component\EventDispatcher\EventDispatcherInterface
+     * @var  \Symfony\Component\EventDispatcher\EventDispatcherInterface
      */
     protected $symfonyDispatcher;
 
@@ -46,20 +46,8 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      */
     public function dispatch($eventName, Event $event = null)
     {
-        if ($event == null)
-        {
-            $event = new Event();
-        }
-
-        $event->setName($eventName);
-        $event->setDispatcher($this);
-
         $this->laravelDispatcher->fire($eventName, $event);
-        $this->symfonyDispatcher->dispatch($eventName, $event);
-
-        $event->setDispatcher($this);
-
-        return $event;
+        return $this->symfonyDispatcher->dispatch($eventName, $event);
     }
 
     /**

--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -137,4 +137,19 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
         return ($this->symfonyDispatcher->hasListeners($eventName) ||
             $this->laravelDispatcher->hasListeners($eventName));
     }
+
+    /**
+     * Gets the listener priority for a specific event.
+     *
+     * Returns null if the event or the listener does not exist.
+     *
+     * @param string   $eventName The name of the event
+     * @param callable $listener  The listener
+     *
+     * @return int|null The event listener priority
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->symfonyDispatcher->getListenerPriority($eventName, $listener);
+    }
 }

--- a/tests/Adapters/AbstractEventDispatcherTest.php
+++ b/tests/Adapters/AbstractEventDispatcherTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tmdb\Laravel\Adapters\Tests;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use Prophecy\Prophecy\MethodProphecy;
+
+abstract class AbstractEventDispatcherTest extends \PHPUnit_Framework_TestCase
+{
+    const EVENT = 'foo';
+
+    /**
+     * @var EventDispatcher
+     */
+    protected $dispatcher;
+
+    protected $laravel;
+    protected $symfony;
+
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->dispatcher = $this->createEventDispatcher();
+    }
+
+    abstract protected function createEventDispatcher();
+
+    /** @test */
+    public function it_dispatches_events_through_both_laravel_and_symfony()
+    {
+        $this->laravel->fire(static::EVENT, null)->shouldBeCalled();
+        $this->symfony->dispatch(static::EVENT, null)->shouldBeCalled();
+
+        $this->dispatcher->dispatch(static::EVENT);
+    }
+
+    /** @test */
+    public function it_returns_the_event_returned_by_the_symfony_dispatcher()
+    {
+        $this->symfony->dispatch(static::EVENT, null)->willReturn('bar');
+        $this->assertEquals('bar', $this->dispatcher->dispatch(static::EVENT));
+    }
+
+    /** @test */
+    public function it_adds_listeners_to_the_symfony_dispatcher()
+    {
+        $this->dispatcher->addListener(static::EVENT, 'listener', 1);
+        $this->symfony->addListener(static::EVENT, 'listener', 1)->shouldHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_adds_a_subscriber_to_the_symfony_dispatcher()
+    {
+        $subscriber = $this->prophesize('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+        $this->dispatcher->addSubscriber($subscriber->reveal());
+        $this->symfony->addSubscriber($subscriber->reveal())->shouldHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_removes_listeners_from_the_symfony_dispathcer()
+    {
+        $this->dispatcher->removeListener(static::EVENT, 'listener');
+        $this->symfony->removeListener(static::EVENT, 'listener')->shouldHaveBeenCalled();
+    }
+
+    /** @test */
+    public function it_removes_subscriptions_from_the_symfony_dispathcer()
+    {
+        $subscriber = $this->prophesize('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+        $this->dispatcher->removeSubscriber($subscriber->reveal());
+        $this->symfony->removeSubscriber($subscriber->reveal())->shouldHaveBeenCalled();
+    }
+
+    /**
+     * @test
+     * We are not checking Laravel's listeners as its interface does not contain a getListeners function
+     */
+    public function it_gets_listeners_from_the_symfony_dispatcher()
+    {
+        $this->symfony->getListeners(static::EVENT)->willReturn(['bar']);
+        $this->assertEquals(['bar'], $this->dispatcher->getListeners(static::EVENT));
+    }
+
+    /** @test */
+    public function it_asks_the_symfony_dispatcher_if_it_has_a_listener()
+    {
+        $this->symfony->hasListeners(static::EVENT)->willReturn(true);
+        $this->assertTrue($this->dispatcher->hasListeners(static::EVENT));
+    }
+
+    /** @test */
+    public function it_asks_the_laravel_dispatcher_if_it_has_a_listener()
+    {
+        $this->symfony->hasListeners(static::EVENT)->willReturn(false);
+        $this->laravel->hasListeners(static::EVENT)->willReturn(true);
+        $this->assertTrue($this->dispatcher->hasListeners(static::EVENT));
+    }
+
+    /** @test */
+    public function it_asks_both_the_symfony_and_laravel_dispatcher_if_it_has_a_listener()
+    {
+        $this->symfony->hasListeners(static::EVENT)->willReturn(false);
+        $this->laravel->hasListeners(static::EVENT)->willReturn(false);
+        $this->assertFalse($this->dispatcher->hasListeners(static::EVENT));
+    }
+
+    /**
+     * @test
+     * We are not checking Laravel's listeners as its interface does not contain a getListenerPriority function
+     */
+    public function it_asks_the_symfony_dispatcher_for_a_listeners_priority()
+    {
+        $this->symfony->getListenerPriority(static::EVENT, 'listener')->willReturn(100);
+        $this->assertEquals(100, $this->dispatcher->getListenerPriority(static::EVENT, 'listener'));
+    }
+}

--- a/tests/Adapters/EventDispatcherTestLaravel4.php
+++ b/tests/Adapters/EventDispatcherTestLaravel4.php
@@ -7,92 +7,17 @@
 namespace Tmdb\Laravel\Adapters\Tests;
 
 use Tmdb\Laravel\Adapters\EventDispatcherLaravel4 as AdapterDispatcher;
-use Illuminate\Events\Dispatcher as LaravelDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyDispatcher;
-
-use Symfony\Component\EventDispatcher\Tests\AbstractEventDispatcherTest;
-use Symfony\Component\EventDispatcher\Tests\TestEventListener;
-use Symfony\Component\EventDispatcher\Tests\TestWithDispatcher;
 
 class EventDispatcherTestLaravel4 extends AbstractEventDispatcherTest
 {
-    private $laravelDispatcher;
-    private $symfonyDispatcher;
-    private $dispatcher;
-
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->dispatcher = $this->createEventDispatcher();
-        $this->listener = new TestEventListener();
-    }
-
     protected function createEventDispatcher()
     {
-        $this->laravelDispatcher = new LaravelDispatcher;
-        $this->symfonyDispatcher = new SymfonyDispatcher;
+        $this->laravel = $this->prophesize('Illuminate\Events\Dispatcher');
+        $this->symfony = $this->prophesize('Symfony\Component\EventDispatcher\EventDispatcher');
+
         return new AdapterDispatcher(
-            $this->laravelDispatcher,
-            $this->symfonyDispatcher
+            $this->laravel->reveal(),
+            $this->symfony->reveal()
         );
     }
-
-    public function testTheEventIsDispatchedTroughLaravel()
-    {
-        $dispatched = false;
-        $this->laravelDispatcher->listen('test', function ($event) use (&$dispatched) {
-            $dispatched = true;
-        });
-        $this->dispatcher->dispatch('test');
-        $this->assertTrue($dispatched);
-    }
-
-    public function testItKnowsIfTheLaravelDispatcherHasListeners()
-    {
-        $this->laravelDispatcher->listen('pre.foo', function() {});
-        $this->laravelDispatcher->listen('post.foo', function() {});
-
-        $this->assertTrue($this->dispatcher->hasListeners('pre.foo'));
-        $this->assertTrue($this->dispatcher->hasListeners('post.foo'));
-    }
-
-
-    /**
-     * The following two tests are copies of the same tests from the
-     * AbstractEventDispatcherTest, however instead of asserting
-     * that the event's dispatcher is the adapter dispatcher, we
-     * assert that it is the Symfony Dispatcher
-     */
-
-    public function testLegacyEventReceivesTheDispatcherInstance()
-    {
-        $dispatcher = null;
-        $this->dispatcher->addListener('test', function ($event) use (&$dispatcher) {
-            $dispatcher = $event->getDispatcher();
-        });
-        $this->dispatcher->dispatch('test');
-        $this->assertSame($this->symfonyDispatcher, $dispatcher);
-    }
-
-    public function testEventReceivesTheDispatcherInstance()
-    {
-        $dispatcher = null;
-        $this->dispatcher->addListener('test', function ($event) use (&$dispatcher) {
-            $dispatcher = $event->getDispatcher();
-        });
-        $this->dispatcher->dispatch('test');
-        $this->assertSame($this->symfonyDispatcher, $dispatcher);
-    }
-
-    public function testEventReceivesTheDispatcherInstanceAsArgument()
-    {
-        $listener = new TestWithDispatcher();
-        $this->dispatcher->addListener('test', array($listener, 'foo'));
-        $this->assertNull($listener->name);
-        $this->assertNull($listener->dispatcher);
-        $this->dispatcher->dispatch('test');
-        $this->assertEquals('test', $listener->name);
-        $this->assertSame($this->symfonyDispatcher, $listener->dispatcher);
-    }
-
 }


### PR DESCRIPTION
This function is required by the interface of event-dispatcher version 3. Moreover this commit fixes a test which was added in event-dispatcher 2.8.