### PR TITLE
Added compatibility with Laravel 5.8

### DIFF
--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -46,7 +46,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      */
     public function dispatch($eventName, Event $event = null)
     {
-        $this->laravelDispatcher->fire($eventName, $event);
+        $this->laravelDispatcher->dispatch($eventName, $event);
         return $this->symfonyDispatcher->dispatch($eventName, $event);
     }
 


### PR DESCRIPTION
The fire method has been removed in Laravel 5.8 and has been deprecated since version 5.4. 