### PR TITLE
Laravel 5.8 support

### DIFF
--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -46,7 +46,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      */
     public function dispatch($eventName, Event $event = null)
     {
-        $this->laravelDispatcher->fire($eventName, $event);
+        $this->laravelDispatcher->dispatch($eventName, $event);
         return $this->symfonyDispatcher->dispatch($eventName, $event);
     }
 


### PR DESCRIPTION
Updated `EventDispatcherAdapter` to use the `dispatch` method on `Illuminate/Events/Dispatcher` instead of the deprecated `fire` method.