### PR TITLE
in EventDispatcherAdapter file, change fire method to dispatch

### DIFF
--- a/src/Adapters/EventDispatcherAdapter.php
+++ b/src/Adapters/EventDispatcherAdapter.php
@@ -46,7 +46,7 @@ abstract class EventDispatcherAdapter implements SymfonyDispatcher
      */
     public function dispatch($eventName, Event $event = null)
     {
-        $this->laravelDispatcher->fire($eventName, $event);
+        $this->laravelDispatcher->dispatch($eventName, $event);
         return $this->symfonyDispatcher->dispatch($eventName, $event);
     }
 


### PR DESCRIPTION
fire method is deprecated,
this change is essential to support laravel 5.8